### PR TITLE
Issue #138 - Fix for overlays to display

### DIFF
--- a/ckanext/geoview/controllers/service_proxy.py
+++ b/ckanext/geoview/controllers/service_proxy.py
@@ -30,7 +30,7 @@ def proxy_service(self, context, data_dict):
         req = self._py_object.request
         method = req.environ["REQUEST_METHOD"]
 
-        url = url.split('#')[0] # remove potential fragment
+        url = url.split('?')[0] # remove potential query and fragment
 
         if method == "POST":
             length = int(req.environ["CONTENT_LENGTH"])

--- a/ckanext/geoview/public/js/ol2_preview.js
+++ b/ckanext/geoview/public/js/ol2_preview.js
@@ -138,7 +138,7 @@
             'wms' : function(resource, proxyUrl, proxyServiceUrl, layerProcessor) {
                 var parsedUrl = resource.url.split('#');
                 // use the original URL for the getMap, as there's no need for a proxy for image requests
-                var getMapUrl = parsedUrl[0];
+                var getMapUrl = parsedUrl[0].split('?')[0]; // remove query if any
 
                 var url = proxyServiceUrl || getMapUrl;
 


### PR DESCRIPTION
https://github.com/bcgov/ckanext-bcgov/issues/138 

One of the parameters is causing the overlay to not display,
'request=GetCapabilities' causes the map server to error/not send the
images needed for the overlay.

The fix now is to drop all of the query strings on the linked resources
so the overlay will display on all uploaded resources.
