### PR TITLE
Issue #231 - Removing bootstrap.min.css links

### DIFF
--- a/ckanext/geoview/templates/dataviewer/openlayers2.html
+++ b/ckanext/geoview/templates/dataviewer/openlayers2.html
@@ -25,5 +25,6 @@
 {% endblock %}
 
 {% block styles %}
-    <link rel="stylesheet" href="{{ h.url_for_static('/css/bootstrap.min.css') }}" type="text/css" media="screen, projection" />
+    {#<link rel="stylesheet" href="{{ h.url_for_static('/vender/bootstrap/2.3.2/css/bootstrap.css') }}" type="text/css" media="screen, projection" />#}
+    {#{% resource 'ckanext-reclineview/bootstrap_style' %}#}
 {% endblock %}

--- a/ckanext/geoview/templates/dataviewer/openlayers3.html
+++ b/ckanext/geoview/templates/dataviewer/openlayers3.html
@@ -20,7 +20,7 @@
 
 {# remove any ckan styles #}
 {% block styles %}
-    <link rel="stylesheet" href="{{ h.url_for_static('/css/bootstrap.min.css') }}" type="text/css" media="screen, projection" />
+    {#<link rel="stylesheet" href="{{ h.url_for_static('/css/bootstrap.min.css') }}" type="text/css" media="screen, projection" />#}
     <link rel="stylesheet" href="http://ol3js.org/en/master/build/ol.css" type="text/css" />
 {% endblock %}
 


### PR DESCRIPTION
Issue bcgov/ckanext-bcgov#231

Removing the links for bootstrap.min.css as they are not needed